### PR TITLE
Fix a keyword argument: "extention" -> "extension"

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ from selective_copy_files import selective_copy
 #  Save local folders
 from_folder = "c:\\user\\my_files"
 to_folder = "c:\\user\\backup_of_my_files"
-extention = "png"
+extension = "png"
 
 # backup folder 
-selective_copy.Copy(from_folder, to_folder, extention)
+selective_copy.Copy(from_folder, to_folder, extension)
 ```

--- a/selective_copy_files.egg-info/PKG-INFO
+++ b/selective_copy_files.egg-info/PKG-INFO
@@ -25,10 +25,10 @@ Description: # Selective copy
         #  Save local folders
         from_folder = "c:\\user\\my_files"
         to_folder = "c:\\user\\backup_of_my_files"
-        extention = "png"
+        extension = "png"
         
         # backup folder 
-        selective_copy.Copy(from_folder, to_folder, extention)
+        selective_copy.Copy(from_folder, to_folder, extension)
         ```
         
 Keywords: copy,slective copy,filter files,auto copy,selective-copy,filter-files,auto-copy

--- a/selective_copy_files/selective_copy.py
+++ b/selective_copy_files/selective_copy.py
@@ -7,14 +7,14 @@ class Copy ():
     Copy a specific file extension in the tree directory 
     """
 
-    def __init__ (self, from_path, to_path, extention): 
+    def __init__ (self, from_path, to_path, extension): 
         """
         Constructor of class. Get paths and extension. Generate file list
         """
 
         self.from_path = from_path
         self.to_path = to_path
-        self.extention = extention
+        self.extension = extension
         self.files = [] 
 
         self.__verify_paths ()
@@ -41,8 +41,8 @@ class Copy ():
         """
 
         # Check correct extension
-        if not self.extention.startswith('.'): 
-            self.extention = '.' + self.extention #Add a dot
+        if not self.extension.startswith('.'): 
+            self.extension = '.' + self.extension #Add a dot
 
         absPath = os.path.abspath(self.from_path)
 
@@ -51,7 +51,7 @@ class Copy ():
             
             # if the file has the correct extension, save complite path
             for file in file_names: 
-                if file.endswith(self.extention):
+                if file.endswith(self.extension):
                     self.files.append(os.path.join(folder_name, file))
     
     def __copy_files (self):


### PR DESCRIPTION
Would normally ignore this, but since this is a keyword argument, it is rather confusing to have to purposely misspell "extension" to get the package to work.